### PR TITLE
Fix problem in client gradle build

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -17,8 +17,8 @@ jar {
 task npmBuild(dependsOn: npmInstall, type: NpmTask) {
     inputs.dir "src"
     inputs.file "gulpfile.js"
-    outputs.dir "build"
-    args = ['run', 'default']
+    outputs.dir "build/dist"
+    args = ['run', 'build']
 }
 
 jar.dependsOn npmBuild

--- a/client/gulp/build.js
+++ b/client/gulp/build.js
@@ -36,7 +36,7 @@ module.exports = function(gulp, config) {
   var paths = config.paths;
   var timestamp = config.timestamp;
 
-  gulp.task('build', ['jshint', 'dist:css', 'dist:js', 'dist:vendors', 'dist:font', 'dist:images', 'dist:favicon', 'dist:index']);
+  gulp.task('build', ['clean', 'ddescriber', 'jshint', 'dist:css', 'dist:js', 'dist:vendors', 'dist:font', 'dist:images', 'dist:favicon', 'dist:index', 'test']);
 
   gulp.task('bundle', ['bundle:vendors', 'bundle:js', 'bundle:css', 'bundle:font', 'bundle:images', 'bundle:favicon', 'bundle:index']);
 

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -58,8 +58,8 @@ gulp.task('serve', function() {
   gulp.start('dev');
 });
 
-gulp.task('default', ['clean', 'ddescriber'], function() {
-  gulp.start(['test', 'build']);
+gulp.task('default', function() {
+  gulp.start(['build']);
 });
 
 module.exports = {


### PR DESCRIPTION
Without this update the site is not generated after a change in client src when you launch ./gradlew bootRun 